### PR TITLE
Fix audio focus

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -581,6 +581,10 @@ class ReactExoplayerView extends FrameLayout implements
         switch (focusChange) {
             case AudioManager.AUDIOFOCUS_LOSS:
                 eventEmitter.audioFocusChanged(false);
+                audioManager.abandonAudioFocus(this);
+                break;
+            case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:
+                eventEmitter.audioFocusChanged(false);
                 break;
             case AudioManager.AUDIOFOCUS_GAIN:
                 eventEmitter.audioFocusChanged(true);


### PR DESCRIPTION
Implement audio focus as per android docs:
https://developer.android.com/guide/topics/media-apps/audio-focus
https://medium.com/androiddevelopers/audio-focus-3-cdc09da9c122

`AUDIOFOCUS_LOSS` should abandon focus and not try resuming audio, this is done with `AUDIOFOCUS_LOSS_TRANSIENT`

This fixes at least:
- Audio not being paused after focus being taken by _some_ voip applications
- Content resuming and pausing instantly sporadically (some race condition perhaps) when activity was resumed from background.
- Same as above but when paused via play/pause button

The above 2 points where happening with this PR implemented: https://github.com/lbryio/lbry-react-native/pull/117

I can only assume that this may also fix the issue of audio continuing to run in the background even though the video was no longer active/playing, reported both on LBRY and ReactNative repos, but I failed to reproduce this issue at the time of testing this, although it did happen to me as well before.